### PR TITLE
Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ unreleased
 * added curl, sudo, node and npm to ubuntu container
 * added ip of 0.0.0.0 to npm run dev command
 * added a rebuild script for when docker container has been updated
+* rebuild script now also does an npm install
 
 0.0.2 / 2013-11-06
 ------------------

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  no-youre-a-docker:
+    build: .
+    image: seaside
+    container_name: landlocked
+    volumes:
+    - "./yesmate:/root/inhere"
+    - /root/inhere/chat/node_modules
+    working_dir: /root/inhere
+    entrypoint: sh install-npm.sh
+    ports:
+      - 8080:1998

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -5,9 +5,9 @@ start.sh
 Dockerfile
 ------------------
 * Base image is Ubuntu
-* Installs python 
+* Installs curl and node
 
-docker-compose.yml
+docker-compose.yml / start.sh
 ------------------
 * one service initially, for the front end ("no-youre-a-docker")
 * builds in current directory
@@ -16,6 +16,18 @@ docker-compose.yml
 * makes the yesmate directory available to the container as /root/inhere
 * runs a python server serving that directory on 1998 (later change to running npm run dev on 1998)
 * maps it to the host on 8080
+* is run by ./start.sh
+
+docker-compose.build.yml / rebuild.sh
+------------------
+* same as docker-compose.yml but also does an npm install, done via an install-npm.sh script instead of direct reference to command
+* is run by ./rebuild.sh
+
+yesmate/install-npm.sh
+------------------
+* runs npm install and then npm run dev
+
+
 
 useful commands / troubleshooting
 ------------------

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,1 +1,3 @@
-docker-compose up --build
+#rebuilds both the image and also does npm install inside container
+docker-compose -f docker-compose.build.yml up --build
+

--- a/yesmate/install-npm.sh
+++ b/yesmate/install-npm.sh
@@ -1,0 +1,4 @@
+echo "installing packages inside container"
+npm install
+npm run dev
+


### PR DESCRIPTION
This is to get around the issue of npm install in container, now the docker script handles it so we don't have to run the npm install command directly

rebuild.sh references its own docker-compose which does both an npm install and npm run dev

we can still run ./start.sh when we dont need to be doing any installing