### PR TITLE
add sourcemap to webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 unreleased
 ------------------
 * use D3 to import frequency data
+* added sourcemap to webpack
 
 0.0.3 / 2017-07-21
 ------------------

--- a/yesmate/webpack.config.js
+++ b/yesmate/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = options => {
     output: {
       filename: 'bundle.js',
     },
+    devtool: 'source-map',
     devServer: {
        port: 1998
     },


### PR DESCRIPTION
Add "devtool: 'source-map'" to webpack config so when troubleshooting we can see the error in eg "nicepage.js" instead of bundle.js